### PR TITLE
fix(deps): update dependencies and fix package configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"build": "turbo build",
 		"dev": "turbo dev",
+		"dev:loose": "turbo dev --env-mode=loose",
 		"check": "biome check . --no-errors-on-unmatched",
 		"check:fix": "biome check . --write --no-errors-on-unmatched",
 		"prepare": "husky"

--- a/packages/ddev/package.json
+++ b/packages/ddev/package.json
@@ -65,13 +65,16 @@
 	},
 	"devDependencies": {
 		"@types/babel__core": "^7.20.1",
+		"@types/babel__generator": "^7.20.1",
 		"@types/diff": "^5.0.3",
 		"@types/fs-extra": "^11.0.1",
+		"@types/node": "^22.14.0",
 		"@types/prompts": "^2.4.2",
 		"@types/stringify-object": "^4.0.5",
 		"rimraf": "^6.0.1",
 		"tsup": "^6.6.3",
 		"type-fest": "^3.8.0",
-		"typescript": "^4.9.3"
+		"typescript": "^4.9.3",
+		"vite-tsconfig-paths": "^5.1.4"
 	}
 }

--- a/packages/domain/src/codec.ts
+++ b/packages/domain/src/codec.ts
@@ -1,4 +1,4 @@
-import { CID, MultihashDigest } from "multiformats";
+import { CID, type MultihashDigest } from "multiformats";
 
 export const isCID = (cid: string) => {
 	try {

--- a/packages/ui-react/src/components/signature/sign.tsx
+++ b/packages/ui-react/src/components/signature/sign.tsx
@@ -8,7 +8,6 @@ import { useAccount, useConfig, useSignMessage } from "wagmi";
 import * as typed from "micro-eth-signer/typed-data";
 import {
 	EIP712Domain,
-	GetType,
 	TypedData,
 	signTyped,
 } from "micro-eth-signer/typed-data";

--- a/packages/ui-react/src/components/social-graph/follower-list-ensjs.tsx
+++ b/packages/ui-react/src/components/social-graph/follower-list-ensjs.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import type { AddressOrEns, EfpFollowerWithName } from "#hooks/ens/efp";
+import { useFollowers } from "#hooks/ens/use-efp-api";
 import { getNames } from "#hooks/ens/use-ensjs";
 import { FollowerListScrollable } from "./follower-list";
-import { useFollowers } from "#hooks/ens/use-efp-api";
 
 /**
  * This one is client-side based dynamic resolving

--- a/packages/ui-react/src/components/social-graph/follower-list-ensjs.tsx
+++ b/packages/ui-react/src/components/social-graph/follower-list-ensjs.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { AddressOrEns, EfpFollowerWithName } from "#hooks/ens/efp";
 import { getNames } from "#hooks/ens/use-ensjs";
 import { FollowerListScrollable } from "./follower-list";
+import { useFollowers } from "#hooks/ens/use-efp-api";
 
 /**
  * This one is client-side based dynamic resolving

--- a/packages/ui-react/src/hooks/eas/sdk/use-attestation.ts
+++ b/packages/ui-react/src/hooks/eas/sdk/use-attestation.ts
@@ -2,10 +2,10 @@ import { SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import { type Signer, ZeroHash } from "ethers";
 import { useMemo } from "react";
 import {
-	Account,
+	type Account,
 	type Address,
 	type Chain,
-	Hex,
+	type Hex,
 	createWalletClient,
 	stringToHex,
 	zeroHash,

--- a/packages/ui-react/src/hooks/signature/use-sign.ts
+++ b/packages/ui-react/src/hooks/signature/use-sign.ts
@@ -2,8 +2,6 @@ import { signMessage } from "@wagmi/core";
 import * as typed from "micro-eth-signer/typed-data";
 import {
 	type EIP712Domain,
-	GetType,
-	TypedData,
 	signTyped,
 } from "micro-eth-signer/typed-data";
 import { useEffect, useRef, useState } from "react";

--- a/packages/ui-react/src/hooks/signature/use-sign.ts
+++ b/packages/ui-react/src/hooks/signature/use-sign.ts
@@ -1,9 +1,6 @@
 import { signMessage } from "@wagmi/core";
 import * as typed from "micro-eth-signer/typed-data";
-import {
-	type EIP712Domain,
-	signTyped,
-} from "micro-eth-signer/typed-data";
+import { type EIP712Domain, signTyped } from "micro-eth-signer/typed-data";
 import { useEffect, useRef, useState } from "react";
 import { useAccount, useConfig, useSignMessage } from "wagmi";
 

--- a/packages/ui-react/src/lib/eas/viem/onchain.ts
+++ b/packages/ui-react/src/lib/eas/viem/onchain.ts
@@ -3,13 +3,13 @@
 
 import {
 	http,
-	Account,
-	Chain,
-	Client,
+	type Account,
+	type Chain,
+	type Client,
 	type Hex,
 	type ReadContractParameters,
-	TransactionReceipt,
-	Transport,
+	type TransactionReceipt,
+	type Transport,
 	type WalletClient,
 	createPublicClient,
 } from "viem";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,16 +19,16 @@ importers:
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.2
-        version: 4.3.2(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))
+        version: 4.3.2(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))
       tsx:
         specifier: ^4.1.4
         version: 4.19.2
       vite:
         specifier: ^5.4.1
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
+        version: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lightningcss@1.29.2)(terser@5.34.1)
+        version: 2.1.8(@types/node@22.14.0)(happy-dom@15.11.6)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lightningcss@1.29.2)(terser@5.34.1)
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: ^1.12.15
@@ -41,7 +41,7 @@ importers:
         version: 2.27.11
       '@graphql-codegen/cli':
         specifier: ^5.0.2
-        version: 5.0.2(@parcel/watcher@2.4.1)(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)
+        version: 5.0.2(@parcel/watcher@2.4.1)(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@graphql-codegen/introspection':
         specifier: ^4.0.3
         version: 4.0.3(encoding@0.1.13)(graphql@16.9.0)
@@ -77,28 +77,28 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^12.2.1
-        version: 12.2.1(@types/node@22.10.2)(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(bufferutil@4.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(utf-8-validate@5.0.10)(yaml@2.5.1)
+        version: 12.2.1(@types/node@22.14.0)(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(bufferutil@4.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(utf-8-validate@5.0.10)(yaml@2.5.1)
       '@astrojs/starlight':
         specifier: ^0.31.1
-        version: 0.31.1(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
+        version: 0.31.1(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
       '@astrojs/starlight-tailwind':
         specifier: ^3.0.1
-        version: 3.0.1(@astrojs/starlight@0.31.1(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)))(@astrojs/tailwind@6.0.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 3.0.1(@astrojs/starlight@0.31.1(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)))(@astrojs/tailwind@6.0.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))
       '@astrojs/tailwind':
         specifier: ^6.0.2
-        version: 6.0.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+        version: 6.0.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
       '@fleek-platform/cli':
         specifier: ^3.8.2
-        version: 3.8.2(@types/node@22.10.2)(encoding@0.1.13)(typescript@5.7.2)
+        version: 3.8.2(@types/node@22.14.0)(encoding@0.1.13)(typescript@5.7.2)
       astro:
         specifier: ^5.1.5
-        version: 5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
+        version: 5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
       sharp:
         specifier: ^0.32.5
         version: 0.32.6
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+        version: 3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
 
   apps/registry:
     dependencies:
@@ -357,10 +357,10 @@ importers:
         version: 2.5.2
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+        version: 3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))
+        version: 1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))
       viem:
         specifier: 2.x
         version: 2.21.16(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -376,13 +376,13 @@ importers:
         version: 1.9.0(react@18.3.1)
       '@ethereum-attestation-service/eas-contracts':
         specifier: 1.7.1
-        version: 1.7.1(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10)
+        version: 1.7.1(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@faker-js/faker':
         specifier: ^8.2.0
         version: 8.4.1
       '@fleek-platform/cli':
         specifier: ^3.8.2
-        version: 3.8.2(@types/node@22.10.2)(encoding@0.1.13)(typescript@5.7.2)
+        version: 3.8.2(@types/node@22.14.0)(encoding@0.1.13)(typescript@5.7.2)
       '@geist/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -412,7 +412,7 @@ importers:
         version: 8.3.4(@storybook/test@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)
       '@storybook/react-vite':
         specifier: ^8.3.4
-        version: 8.3.4(@storybook/test@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)
+        version: 8.3.4(@storybook/test@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)
       '@storybook/test':
         specifier: ^8.3.4
         version: 8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
@@ -433,7 +433,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.2(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))
+        version: 4.3.2(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -457,13 +457,13 @@ importers:
         version: 8.13.0(eslint@9.14.0(jiti@2.4.2))(typescript@5.7.2)
       vite:
         specifier: ^5.4.1
-        version: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
+        version: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
       vite-plugin-node-polyfills:
         specifier: ^0.22.0
-        version: 0.22.0(rollup@4.34.6)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))
+        version: 0.22.0(rollup@4.34.6)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lightningcss@1.29.2)(terser@5.34.1)
+        version: 2.1.8(@types/node@22.14.0)(happy-dom@15.11.6)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lightningcss@1.29.2)(terser@5.34.1)
       wagmi:
         specifier: ^2.12.16
         version: 2.12.16(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.56.2(react@18.3.1))(@types/react@18.3.18)(bufferutil@4.0.8)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.3(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.3.18)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.7.2)(utf-8-validate@5.0.10))(react@18.3.1)(rollup@4.34.6)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.21.16(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
@@ -546,12 +546,18 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.5
+      '@types/babel__generator':
+        specifier: ^7.20.1
+        version: 7.27.0
       '@types/diff':
         specifier: ^5.0.3
         version: 5.2.3
       '@types/fs-extra':
         specifier: ^11.0.1
         version: 11.0.4
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.14.0
       '@types/prompts':
         specifier: ^2.4.2
         version: 2.4.9
@@ -563,13 +569,16 @@ importers:
         version: 6.0.1
       tsup:
         specifier: ^6.6.3
-        version: 6.7.0(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@4.9.5))(typescript@4.9.5)
+        version: 6.7.0(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.14.0)(typescript@4.9.5))(typescript@4.9.5)
       type-fest:
         specifier: ^3.8.0
         version: 3.13.1
       typescript:
         specifier: ^4.9.3
         version: 4.9.5
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@4.9.5)(vite@6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1))
 
   packages/domain:
     dependencies:
@@ -714,13 +723,13 @@ importers:
     devDependencies:
       '@graphprotocol/graph-cli':
         specifier: ^0.67.2
-        version: 0.67.4(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@3.3.2)(typescript@5.7.2)(utf-8-validate@5.0.10)
+        version: 0.67.4(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@3.3.2)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@graphprotocol/graph-ts':
         specifier: ^0.31.0
         version: 0.31.0
       '@graphql-codegen/cli':
         specifier: ^5.0.2
-        version: 5.0.2(@parcel/watcher@2.4.1)(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)
+        version: 5.0.2(@parcel/watcher@2.4.1)(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)
       '@graphql-codegen/schema-ast':
         specifier: ^4.1.0
         version: 4.1.0(graphql@16.9.0)
@@ -6142,8 +6151,8 @@ packages:
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
-  '@types/babel__generator@7.6.8':
-    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
 
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
@@ -6315,6 +6324,9 @@ packages:
 
   '@types/node@22.10.2':
     resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/node@8.10.66':
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -13776,6 +13788,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
@@ -14153,6 +14168,14 @@ packages:
     resolution: {integrity: sha512-F+G3LjiGbG8QpbH9bZ//GSBr9i1InSTkaulfUHFa9jkLqVGORFBoqc2A/Yu5Mmh1kNAbiAeKeK+6aaQUf3x0JA==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.4.8:
     resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
@@ -14776,18 +14799,18 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@astrojs/cloudflare@12.2.1(@types/node@22.10.2)(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(bufferutil@4.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(utf-8-validate@5.0.10)(yaml@2.5.1)':
+  '@astrojs/cloudflare@12.2.1(@types/node@22.14.0)(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(bufferutil@4.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(utf-8-validate@5.0.10)(yaml@2.5.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.2
       '@astrojs/underscore-redirects': 0.6.0
       '@cloudflare/workers-types': 4.20250204.0
-      astro: 5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
+      astro: 5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
       esbuild: 0.24.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
       miniflare: 3.20250204.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tiny-glob: 0.2.9
-      vite: 6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
+      vite: 6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
       wrangler: 3.108.1(@cloudflare/workers-types@4.20250204.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@types/node'
@@ -14835,12 +14858,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.0.8(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))':
+  '@astrojs/mdx@4.0.8(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.1.0
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       acorn: 8.14.0
-      astro: 5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
+      astro: 5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.4
@@ -14864,22 +14887,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.24.2
 
-  '@astrojs/starlight-tailwind@3.0.1(@astrojs/starlight@0.31.1(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)))(@astrojs/tailwind@6.0.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))':
+  '@astrojs/starlight-tailwind@3.0.1(@astrojs/starlight@0.31.1(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)))(@astrojs/tailwind@6.0.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))':
     dependencies:
-      '@astrojs/starlight': 0.31.1(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
-      '@astrojs/tailwind': 6.0.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
-      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+      '@astrojs/starlight': 0.31.1(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
+      '@astrojs/tailwind': 6.0.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
 
-  '@astrojs/starlight@0.31.1(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))':
+  '@astrojs/starlight@0.31.1(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))':
     dependencies:
-      '@astrojs/mdx': 4.0.8(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
+      '@astrojs/mdx': 4.0.8(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
       '@astrojs/sitemap': 3.3.0
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
-      astro-expressive-code: 0.40.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
+      astro: 5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
+      astro-expressive-code: 0.40.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.3
@@ -14900,13 +14923,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/tailwind@6.0.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))':
+  '@astrojs/tailwind@6.0.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))':
     dependencies:
-      astro: 5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
+      astro: 5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
       autoprefixer: 10.4.21(postcss@8.5.3)
       postcss: 8.5.3
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
-      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
+      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
     transitivePeerDependencies:
       - ts-node
 
@@ -16906,6 +16929,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@ethereum-attestation-service/eas-contracts@1.7.1(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      hardhat: 2.22.4(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - c-kzg
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+
   '@ethereum-attestation-service/eas-sdk@2.6.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10)(zod@3.23.8)':
     dependencies:
       '@ethereum-attestation-service/eas-contracts': 1.7.1(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10)
@@ -17287,6 +17321,49 @@ snapshots:
       - supports-color
       - typescript
 
+  '@fleek-platform/cli@3.8.2(@types/node@22.14.0)(encoding@0.1.13)(typescript@5.7.2)':
+    dependencies:
+      '@aws-sdk/client-lambda': 3.675.0
+      '@fleek-platform/functions-esbuild-config': 0.0.19(esbuild@0.21.5)
+      '@web-std/file': 3.0.3
+      ansi-escapes: 3.2.0
+      as-table: 1.0.55
+      aws4: 1.13.2
+      axios: 1.7.7
+      boxen: 5.1.2
+      chalk: 4.1.2
+      cli-progress: 3.12.0
+      commander: 9.5.0
+      conf: 10.2.0
+      dotenv: 16.4.5
+      eciesjs: 0.4.7
+      esbuild: 0.21.5
+      files-from-path: 1.0.4
+      glob: 8.1.0
+      hash-wasm: 4.11.0
+      importx: 0.5.1
+      lodash-es: 4.17.21
+      multiformats: 9.9.0
+      nanoid: 3.3.7
+      native-fetch: 4.0.2(undici@6.21.0)
+      ora: 3.4.0
+      press-any-key: 0.1.1
+      prompts: 2.4.2
+      semver: 7.6.3
+      ts-node: 10.9.1(@types/node@22.14.0)(typescript@5.7.2)
+      undici: 6.21.0
+      unique-names-generator: 4.7.1
+      update-notifier-cjs: 5.1.6(encoding@0.1.13)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - aws-crt
+      - debug
+      - encoding
+      - supports-color
+      - typescript
+
   '@fleek-platform/functions-esbuild-config@0.0.19(esbuild@0.21.5)':
     dependencies:
       esbuild: 0.21.5
@@ -17329,12 +17406,12 @@ snapshots:
       graphql: 16.9.0
       typescript: 5.7.2
 
-  '@graphprotocol/graph-cli@0.67.4(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@3.3.2)(typescript@5.7.2)(utf-8-validate@5.0.10)':
+  '@graphprotocol/graph-cli@0.67.4(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@3.3.2)(typescript@5.7.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@float-capital/float-subgraph-uncrashable': 0.0.0-internal-testing.5
-      '@oclif/core': 2.8.6(@types/node@22.10.2)(typescript@5.7.2)
-      '@oclif/plugin-autocomplete': 2.3.10(@types/node@22.10.2)(typescript@5.7.2)
-      '@oclif/plugin-not-found': 2.4.3(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/core': 2.8.6(@types/node@22.14.0)(typescript@5.7.2)
+      '@oclif/plugin-autocomplete': 2.3.10(@types/node@22.14.0)(typescript@5.7.2)
+      '@oclif/plugin-not-found': 2.4.3(@types/node@22.14.0)(typescript@5.7.2)
       '@whatwg-node/fetch': 0.8.8
       assemblyscript: 0.19.23
       binary-install-raw: 0.0.13(debug@4.3.4)
@@ -17379,7 +17456,7 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@5.0.2(@parcel/watcher@2.4.1)(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)':
+  '@graphql-codegen/cli@5.0.2(@parcel/watcher@2.4.1)(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(enquirer@2.4.1)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/generator': 7.25.6
       '@babel/template': 7.25.0
@@ -17390,12 +17467,12 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 8.0.1(encoding@0.1.13)(graphql@16.9.0)
       '@graphql-tools/code-file-loader': 8.1.3(graphql@16.9.0)
       '@graphql-tools/git-loader': 8.0.7(graphql@16.9.0)
-      '@graphql-tools/github-loader': 8.0.1(@types/node@22.10.2)(encoding@0.1.13)(graphql@16.9.0)
+      '@graphql-tools/github-loader': 8.0.1(@types/node@22.14.0)(encoding@0.1.13)(graphql@16.9.0)
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/load': 8.0.2(graphql@16.9.0)
-      '@graphql-tools/prisma-loader': 8.0.4(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
+      '@graphql-tools/prisma-loader': 8.0.4(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
@@ -17403,7 +17480,7 @@ snapshots:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.9.0
-      graphql-config: 5.1.2(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)
+      graphql-config: 5.1.2(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.6
@@ -17608,14 +17685,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@graphql-tools/executor-http@1.1.6(@types/node@22.10.2)(graphql@16.9.0)':
+  '@graphql-tools/executor-http@1.1.6(@types/node@22.14.0)(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/fetch': 0.9.21
       extract-files: 11.0.0
       graphql: 16.9.0
-      meros: 1.3.0(@types/node@22.10.2)
+      meros: 1.3.0(@types/node@22.14.0)
       tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -17654,10 +17731,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@8.0.1(@types/node@22.10.2)(encoding@0.1.13)(graphql@16.9.0)':
+  '@graphql-tools/github-loader@8.0.1(@types/node@22.14.0)(encoding@0.1.13)(graphql@16.9.0)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1(encoding@0.1.13)
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.10.2)(graphql@16.9.0)
+      '@graphql-tools/executor-http': 1.1.6(@types/node@22.14.0)(graphql@16.9.0)
       '@graphql-tools/graphql-tag-pluck': 8.3.2(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@whatwg-node/fetch': 0.9.21
@@ -17725,9 +17802,9 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
 
-  '@graphql-tools/prisma-loader@8.0.4(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)':
+  '@graphql-tools/prisma-loader@8.0.4(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)':
     dependencies:
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.9.21
@@ -17769,12 +17846,12 @@ snapshots:
       tslib: 2.8.1
       value-or-promise: 1.0.12
 
-  '@graphql-tools/url-loader@8.0.2(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)':
+  '@graphql-tools/url-loader@8.0.2(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1(encoding@0.1.13)
       '@graphql-tools/delegate': 10.0.21(graphql@16.9.0)
       '@graphql-tools/executor-graphql-ws': 1.3.0(bufferutil@4.0.8)(graphql@16.9.0)(utf-8-validate@5.0.10)
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.10.2)(graphql@16.9.0)
+      '@graphql-tools/executor-http': 1.1.6(@types/node@22.14.0)(graphql@16.9.0)
       '@graphql-tools/executor-legacy-ws': 1.1.0(bufferutil@4.0.8)(graphql@16.9.0)(utf-8-validate@5.0.10)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@graphql-tools/wrap': 10.0.5(graphql@16.9.0)
@@ -17993,14 +18070,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -18013,7 +18090,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -18022,17 +18099,17 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.7.2)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.7.2)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))':
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.2)
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
     optionalDependencies:
       typescript: 5.7.2
 
@@ -18555,7 +18632,7 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@oclif/core@2.16.0(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/core@2.16.0(@types/node@22.14.0)(typescript@5.7.2)':
     dependencies:
       '@types/cli-progress': 3.11.6
       ansi-escapes: 4.3.2
@@ -18580,7 +18657,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.2)
       tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -18591,7 +18668,7 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@oclif/core@2.8.6(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/core@2.8.6(@types/node@22.14.0)(typescript@5.7.2)':
     dependencies:
       '@types/cli-progress': 3.11.6
       ansi-escapes: 4.3.2
@@ -18617,7 +18694,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.2)
       tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -18628,9 +18705,9 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@oclif/plugin-autocomplete@2.3.10(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/plugin-autocomplete@2.3.10(@types/node@22.14.0)(typescript@5.7.2)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/core': 2.16.0(@types/node@22.14.0)(typescript@5.7.2)
       chalk: 4.1.2
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -18640,9 +18717,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@oclif/plugin-not-found@2.4.3(@types/node@22.10.2)(typescript@5.7.2)':
+  '@oclif/plugin-not-found@2.4.3(@types/node@22.14.0)(typescript@5.7.2)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@22.10.2)(typescript@5.7.2)
+      '@oclif/core': 2.16.0(@types/node@22.14.0)(typescript@5.7.2)
       chalk: 4.1.2
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -21380,7 +21457,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)':
+  '@storybook/builder-vite@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)':
     dependencies:
       '@storybook/csf-plugin': 8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(webpack-sources@3.2.3)
       '@types/find-cache-dir': 3.2.1
@@ -21392,7 +21469,7 @@ snapshots:
       magic-string: 0.30.11
       storybook: 8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -21462,11 +21539,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  '@storybook/react-vite@8.3.4(@storybook/test@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)':
+  '@storybook/react-vite@8.3.4(@storybook/test@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.7.2)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.7.2)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))
       '@rollup/pluginutils': 5.1.2(rollup@4.34.6)
-      '@storybook/builder-vite': 8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)
+      '@storybook/builder-vite': 8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))(webpack-sources@3.2.3)
       '@storybook/react': 8.3.4(@storybook/test@8.3.4(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.7.2)
       find-up: 5.0.0
       magic-string: 0.30.11
@@ -21476,7 +21553,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.3.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
-      vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - '@storybook/test'
@@ -21682,11 +21759,11 @@ snapshots:
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      '@types/babel__generator': 7.6.8
+      '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
-  '@types/babel__generator@7.6.8':
+  '@types/babel__generator@7.27.0':
     dependencies:
       '@babel/types': 7.25.6
 
@@ -21701,28 +21778,28 @@ snapshots:
 
   '@types/bn.js@4.11.6':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/bn.js@5.1.6':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/cookie@0.6.0': {}
 
@@ -21772,7 +21849,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       '@types/qs': 6.9.16
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -21788,17 +21865,17 @@ snapshots:
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -21827,7 +21904,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/lodash@4.17.9': {}
 
@@ -21855,7 +21932,7 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/node@10.17.60': {}
 
@@ -21869,17 +21946,21 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@8.10.66': {}
 
   '@types/parse-json@4.0.2': {}
 
   '@types/pbkdf2@3.1.2':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       kleur: 3.0.3
 
   '@types/prop-types@15.7.13': {}
@@ -21903,21 +21984,21 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/secp256k1@4.0.6':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       '@types/send': 0.17.4
 
   '@types/stack-utils@2.0.3': {}
@@ -21928,7 +22009,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/tinycolor2@1.4.6': {}
 
@@ -21948,11 +22029,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -22116,6 +22197,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@4.3.2(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.0.5':
     dependencies:
       '@vitest/spy': 2.0.5
@@ -22137,6 +22229,14 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
+
+  '@vitest/mocker@2.1.8(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -23002,12 +23102,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.40.2(astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)):
+  astro-expressive-code@0.40.2(astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)):
     dependencies:
-      astro: 5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
+      astro: 5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1)
       rehype-expressive-code: 0.40.2
 
-  astro@5.2.6(@types/node@22.10.2)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1):
+  astro@5.2.6(@types/node@22.14.0)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.6)(terser@5.34.1)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.5.1):
     dependencies:
       '@astrojs/compiler': 2.10.4
       '@astrojs/internal-helpers': 0.5.1
@@ -23059,8 +23159,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.14.4(idb-keyval@6.2.1)
       vfile: 6.0.3
-      vite: 6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
-      vitefu: 1.0.5(vite@6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1))
+      vite: 6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
+      vitefu: 1.0.5(vite@6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -23776,7 +23876,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -23785,7 +23885,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -25842,13 +25942,13 @@ snapshots:
       - graphql
       - supports-color
 
-  graphql-config@5.1.2(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10):
+  graphql-config@5.1.2(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(typescript@5.7.2)(utf-8-validate@5.0.10):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/load': 8.0.2(graphql@16.9.0)
       '@graphql-tools/merge': 9.0.7(graphql@16.9.0)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.10.2)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.14.0)(bufferutil@4.0.8)(encoding@0.1.13)(graphql@16.9.0)(utf-8-validate@5.0.10)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       cosmiconfig: 9.0.0(typescript@5.7.2)
       graphql: 16.9.0
@@ -26038,6 +26138,60 @@ snapshots:
       ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
       ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - c-kzg
+      - supports-color
+      - utf-8-validate
+
+  hardhat@2.22.4(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))(typescript@5.7.2)(utf-8-validate@5.0.10):
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@metamask/eth-sig-util': 4.0.1
+      '@nomicfoundation/edr': 0.3.8
+      '@nomicfoundation/ethereumjs-common': 4.0.4
+      '@nomicfoundation/ethereumjs-tx': 5.0.4
+      '@nomicfoundation/ethereumjs-util': 9.0.4
+      '@nomicfoundation/solidity-analyzer': 0.1.2
+      '@sentry/node': 5.30.0
+      '@types/bn.js': 5.1.6
+      '@types/lru-cache': 5.1.1
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chalk: 2.4.2
+      chokidar: 3.6.0
+      ci-info: 2.0.0
+      debug: 4.4.0(supports-color@8.1.1)
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      ethereumjs-abi: 0.6.8
+      find-up: 2.1.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      glob: 7.2.0
+      immutable: 4.3.7
+      io-ts: 1.10.4
+      keccak: 3.0.4
+      lodash: 4.17.21
+      mnemonist: 0.38.5
+      mocha: 10.7.3
+      p-map: 4.0.0
+      raw-body: 2.5.2
+      resolve: 1.17.0
+      semver: 6.3.1
+      solc: 0.7.3(debug@4.4.0)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.10
+      tsort: 0.0.1
+      undici: 5.28.4
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -26990,7 +27144,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -27011,13 +27165,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       jest-util: 29.7.0
 
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -27034,7 +27188,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -27802,9 +27956,9 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meros@1.3.0(@types/node@22.10.2):
+  meros@1.3.0(@types/node@22.14.0):
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
 
   methods@1.1.2: {}
 
@@ -29212,13 +29366,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.2
 
-  postcss-load-config@3.1.4(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@4.9.5)):
+  postcss-load-config@3.1.4(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.14.0)(typescript@4.9.5)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.5.2
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@4.9.5)
 
   postcss-load-config@4.0.2(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
     dependencies:
@@ -29228,13 +29382,21 @@ snapshots:
       postcss: 8.5.2
       ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
 
-  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
+  postcss-load-config@4.0.2(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.5.1
+    optionalDependencies:
+      postcss: 8.5.2
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.2)
+
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.1
     optionalDependencies:
       postcss: 8.5.3
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.2)
 
   postcss-nested@6.2.0(postcss@8.5.2):
     dependencies:
@@ -29374,7 +29536,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       long: 4.0.0
 
   protobufjs@7.4.0:
@@ -29389,7 +29551,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       long: 5.2.3
 
   proxy-addr@2.0.7:
@@ -31007,6 +31169,10 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
 
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))):
+    dependencies:
+      tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
+
   tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -31027,6 +31193,33 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.5.2)
       postcss-js: 4.0.1(postcss@8.5.2)
       postcss-load-config: 4.0.2(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+      postcss-nested: 6.2.0(postcss@8.5.2)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
+  tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.6
+      lilconfig: 2.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.0
+      postcss: 8.5.2
+      postcss-import: 15.1.0(postcss@8.5.2)
+      postcss-js: 4.0.1(postcss@8.5.2)
+      postcss-load-config: 4.0.2(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2))
       postcss-nested: 6.2.0(postcss@8.5.2)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -31302,24 +31495,23 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.10.2)(typescript@4.9.5):
+  ts-node@10.9.1(@types/node@22.14.0)(typescript@5.7.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.10.2
-      acorn: 8.12.1
+      '@types/node': 22.14.0
+      acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.7.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2):
     dependencies:
@@ -31339,7 +31531,48 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@22.14.0)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.14.0
+      acorn: 8.12.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.14.0
+      acorn: 8.12.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
   ts-toolbelt@9.6.0: {}
+
+  tsconfck@3.1.5(typescript@4.9.5):
+    optionalDependencies:
+      typescript: 4.9.5
 
   tsconfck@3.1.5(typescript@5.7.2):
     optionalDependencies:
@@ -31365,7 +31598,7 @@ snapshots:
 
   tsort@0.0.1: {}
 
-  tsup@6.7.0(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@4.9.5))(typescript@4.9.5):
+  tsup@6.7.0(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.14.0)(typescript@4.9.5))(typescript@4.9.5):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.17.19)
       cac: 6.7.14
@@ -31375,7 +31608,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@4.9.5))
+      postcss-load-config: 3.1.4(postcss@8.5.2)(ts-node@10.9.2(@types/node@22.14.0)(typescript@4.9.5))
       resolve-from: 5.0.0
       rollup: 3.29.5
       source-map: 0.8.0-beta.0
@@ -31522,6 +31755,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.20.0: {}
+
+  undici-types@6.21.0: {}
 
   undici@5.28.4:
     dependencies:
@@ -31891,6 +32126,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0(supports-color@8.1.1)
+      es-module-lexer: 1.5.4
+      pathe: 1.1.2
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-node-polyfills@0.22.0(rollup@4.34.6)(vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.34.6)
@@ -31898,6 +32151,25 @@ snapshots:
       vite: 5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1)
     transitivePeerDependencies:
       - rollup
+
+  vite-plugin-node-polyfills@0.22.0(rollup@4.34.6)(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)):
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.34.6)
+      node-stdlib-browser: 1.3.0
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
+    transitivePeerDependencies:
+      - rollup
+
+  vite-tsconfig-paths@5.1.4(typescript@4.9.5)(vite@6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)):
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      globrex: 0.1.2
+      tsconfck: 3.1.5(typescript@4.9.5)
+    optionalDependencies:
+      vite: 6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@5.4.8(@types/node@22.10.2)(lightningcss@1.29.2)(terser@5.34.1):
     dependencies:
@@ -31910,13 +32182,24 @@ snapshots:
       lightningcss: 1.29.2
       terser: 5.34.1
 
-  vite@6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1):
+  vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.2
+      rollup: 4.22.5
+    optionalDependencies:
+      '@types/node': 22.14.0
+      fsevents: 2.3.3
+      lightningcss: 1.29.2
+      terser: 5.34.1
+
+  vite@6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.14.0
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
@@ -31924,9 +32207,9 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.5.1
 
-  vitefu@1.0.5(vite@6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)):
+  vitefu@1.0.5(vite@6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)):
     optionalDependencies:
-      vite: 6.1.0(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
+      vite: 6.1.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.34.1)(tsx@4.19.2)(yaml@2.5.1)
 
   vitest@2.1.8(@types/node@22.10.2)(happy-dom@15.11.6)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lightningcss@1.29.2)(terser@5.34.1):
     dependencies:
@@ -31952,6 +32235,43 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.2
+      happy-dom: 15.11.6
+      jsdom: 25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.8(@types/node@22.14.0)(happy-dom@15.11.6)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lightningcss@1.29.2)(terser@5.34.1):
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1))
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0(supports-color@8.1.1)
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
+      vite-node: 2.1.8(@types/node@22.14.0)(lightningcss@1.29.2)(terser@5.34.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.14.0
       happy-dom: 15.11.6
       jsdom: 25.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:


### PR DESCRIPTION
## Background:

One would fail to run the project by simply running `pnpm dev`. This fix the dependencies and add a new command `pnpm dev:loose` for passing the env variables in global scope.

## Commits:

chore(deps): update @types/babel__generator and @types/node versions

fix: add 'dev:loose' script to package.json for loose environment mode

fix: restore formatting of files and keywords in package.json

fix: update package.json to include @types/node in devDependencies

fix: add vite-tsconfig-paths dependency to package.json and pnpm-lock.yaml

fix: add type annotations for Account, Chain, Client, TransactionReceipt, and Transport imports